### PR TITLE
update some mistakes in syntax file

### DIFF
--- a/syntax/smali.vim
+++ b/syntax/smali.vim
@@ -84,7 +84,7 @@ syn keyword dalvikInstruction invoke-virtual-quick/range invoke-super-quick/rang
 
 " class names (between L and ;)
 syn match dalvikName "L\([a-zA-Z_][a-zA-Z_0-9]*/\)*[a-zA-Z_][a-zA-Z_0-9]*\(\$\([a-zA-Z_][a-zA-Z_0-9]*\)\?\)\?;"hs=s+1,he=e-1
-syn region dalvikString start=+"+ end=+"+
+syn match dalvikString ;"\([^"\\]\|\\['"?\\abfnrtv]\|\\[0-7]\{1,3\}\|\\[Xx][0-9a-fA-F]\{2\}\)*";
 
 " branch labels
 syn match dalvikLabel "\<[A-Za-z0-9_]\+\>:$"

--- a/syntax/smali.vim
+++ b/syntax/smali.vim
@@ -34,6 +34,7 @@ syn match dalvikDirective /\.restart\s\+local/
 syn keyword dalvikAccess public private protected static final synchronized bridge varargs
 syn keyword dalvikAccess native abstract strictfp synthetic constructor declared-synchronized
 syn keyword dalvikAccess interface enum annotation volatile transient
+syn match dalvikAccess "<init>"
 
 " instructions
 syn keyword dalvikInstruction goto return-void nop const/4 move-result move-result-wide 

--- a/syntax/smali.vim
+++ b/syntax/smali.vim
@@ -23,7 +23,7 @@ syn keyword dalvikDirective .subannotation .annotation
 syn keyword dalvikDirective .enum .method .registers .locals .array-data
 syn keyword dalvikDirective .packed-switch 
 syn keyword dalvikDirective .sparse-switch .catch .catchall .line
-syn keyword dalvikDirective .parameter .local 
+syn keyword dalvikDirective .parameter .param .local
 syn keyword dalvikDirective .prologue .epilogue
 syn keyword dalvikDirective .source
 syn match dalvikDirective /\.end\s\+\(field\|subannotation\|annotation\|method\|array-data\)/

--- a/syntax/smali.vim
+++ b/syntax/smali.vim
@@ -87,7 +87,7 @@ syn match dalvikName "L\([a-zA-Z_][a-zA-Z_0-9]*/\)*[a-zA-Z_][a-zA-Z_0-9]*\(\$\([
 syn match dalvikString ;"\([^"\\]\|\\['"?\\abfnrtv]\|\\[0-7]\{1,3\}\|\\[Xx][0-9a-fA-F]\{2\}\)*";
 
 " branch labels
-syn match dalvikLabel "\<[A-Za-z0-9_]\+\>:$"
+syn match dalvikLabel "^ \+:\<[A-Za-z0-9_]\+\>$"
 
 " registers
 syn match dalvikRegister "\<[vp]\d\+\>"

--- a/syntax/smali.vim
+++ b/syntax/smali.vim
@@ -83,7 +83,7 @@ syn keyword dalvikInstruction invoke-static/range invoke-interface/range filled-
 syn keyword dalvikInstruction invoke-virtual-quick/range invoke-super-quick/range const-wide 
 
 " class names (between L and ;)
-syn match dalvikName "L[^();:]\+;"hs=s+1,he=e-1
+syn match dalvikName "L\([a-zA-Z_][a-zA-Z_0-9]*/\)*[a-zA-Z_][a-zA-Z_0-9]*\(\$\([a-zA-Z_][a-zA-Z_0-9]*\)\?\)\?;"hs=s+1,he=e-1
 syn region dalvikString start=+"+ end=+"+
 
 " branch labels

--- a/syntax/smali.vim
+++ b/syntax/smali.vim
@@ -28,7 +28,7 @@ syn keyword dalvikDirective .prologue .epilogue
 syn keyword dalvikDirective .source
 syn match dalvikDirective /\.end\s\+\(field\|subannotation\|annotation\|method\|array-data\)/
 syn match dalvikDirective /\.end\s\+\(packed-switch\|sparse-switch\|parameter\|local\)/
-syn match dalvikDirective /\.restart\s+local/
+syn match dalvikDirective /\.restart\s\+local/
 
 " access modifiers
 syn keyword dalvikAccess public private protected static final synchronized bridge varargs


### PR DESCRIPTION
* `46d2a75` (HEAD -> master, origin/master, origin/HEAD) add <init> method name to dalvikAccess group
* `5315932` fix regexp mistake for labels
* `a44b135` update regexp for string with more precise one
* `34fa660` update regexp for L...; with more precise one
* `617f347` fix regexp mistake for .restart local
* `f7802da` add .param to directives

also pull requests to original klewin/vim-smali repo